### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,6 @@ EDFAPI_INC="/usr/include/EyeLink"
 
 #### Mac OS
 
-> **Warning**  
-> Currently (27.09.2022) eyelinkReader _does not_ work on ARM Macs because EDF API library is compiled for Intel-architecture and the linker fails with an error `building for macOS-arm64 but attempting to link with file built for macOS-x86_64`. The issue will resolve itself once SR-Research publishes an EyeLink Developers Kit built for ARM architecture but there is nothing  I can do at my end.
-
 * `EDFAPI_LIB`: path to EDF API framework. Defaults to `/Library/Frameworks`
 * `EDFAPI_INC` : path to C header files necessary for compilation. Specifically, the package requires _edf.h_, _edf_data.h_, and _edftypes.h_. Defaults to `/Library/Frameworks/edfapi.framework/Headers`
 


### PR DESCRIPTION
I've deleted the warning, because SR Research finally has a version that works with M1 Macs. They've confirmed it works with EyelinkReader, and I've now gotten it to work as well! It's on their normal downloads page now https://www.sr-research.com/support/thread-13.html