### PR TITLE
Update zzz.R

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -67,7 +67,7 @@
     include_path <- locate_files(required_headers,
                                  c(Sys.getenv("EDFAPI_INC"),
                                    '/Library/Frameworks/edfapi.framework/Headers/'))
-    library_path <-'/Library/Frameworks/edfapi.framework/'
+    library_path <-'/Library/Frameworks/'
     if (!is.null(include_path)) {
       Sys.setenv("PKG_CXXFLAGS"=sprintf('-I"%s"', include_path))
       Sys.setenv("PKG_LIBS"=sprintf('-framework edfapi -F%s -rpath %s', library_path, library_path))


### PR DESCRIPTION
Remove redundant 'edfapi.framework/' part of library path for Darwin.

I have now confirmed that this works on four Mac laptops here (one M1 MacBook Pro, and 3 Airs of various vintages and operating system versions) and one Windows laptop (Windows should not have been affected).